### PR TITLE
Fix various problems with config handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,17 +126,23 @@ function mergeTOML(
   overrides: Record<string, toml.TomlPrimitive>
 ): Record<string, toml.TomlPrimitive> {
   return Object.fromEntries(
-    Object.keys({ ...base, ...overrides }).map((key, _) => [
-      key,
-      base[key] instanceof Object &&
-      !(base[key] instanceof toml.TomlDate) &&
-      !(base[key] instanceof Array) &&
-      overrides[key] instanceof Object &&
-      !(overrides[key] instanceof toml.TomlDate) &&
-      !(overrides[key] instanceof Array)
-        ? mergeTOML(base[key], overrides[key])
-        : (overrides[key] ?? base[key])
-    ])
+    Object.keys({ ...base, ...overrides })
+      .map((key, _): [string, toml.TomlPrimitive, toml.TomlPrimitive] => [
+        key,
+        base[key],
+        overrides[key]
+      ])
+      .map(([key, value, override]) => [
+        key,
+        value instanceof Object &&
+        !(value instanceof toml.TomlDate) &&
+        !(value instanceof Array) &&
+        override instanceof Object &&
+        !(override instanceof toml.TomlDate) &&
+        !(override instanceof Array)
+          ? mergeTOML(value, override)
+          : (override ?? value)
+      ])
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,16 +126,16 @@ function mergeTOML(
   overrides: Record<string, toml.TomlPrimitive>
 ): Record<string, toml.TomlPrimitive> {
   return Object.fromEntries(
-    Object.entries({ ...overrides, ...base }).map(([key, value], _) => [
+    Object.keys({ ...base, ...overrides }).map((key, _) => [
       key,
-      value instanceof Object &&
-      !(value instanceof toml.TomlDate) &&
-      !(value instanceof Array) &&
+      base[key] instanceof Object &&
+      !(base[key] instanceof toml.TomlDate) &&
+      !(base[key] instanceof Array) &&
       overrides[key] instanceof Object &&
       !(overrides[key] instanceof toml.TomlDate) &&
       !(overrides[key] instanceof Array)
-        ? mergeTOML(value, overrides[key])
-        : (overrides[key] ?? value)
+        ? mergeTOML(base[key], overrides[key])
+        : (overrides[key] ?? base[key])
     ])
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,19 @@ function mergeTOML(
 }
 
 /**
+ * Extracts the Ruff config section from a pyproject-like TOML config.
+ */
+function configRuffSection(
+  config: Record<string, toml.TomlPrimitive>
+): Record<string, toml.TomlPrimitive> | undefined {
+  if (!((config as any)?.['tool']?.['ruff'] instanceof Object)) {
+    return undefined;
+  }
+
+  return (config as any)['tool']['ruff'];
+}
+
+/**
  * Sets up a {@see Workspace} from the surrounding Ruff config files.
  *
  * See: https://docs.astral.sh/ruff/configuration/#config-file-discovery
@@ -178,19 +191,6 @@ async function workspaceFromEnvironment(
   } while (directory !== '');
 
   return new Workspace(overrides);
-}
-
-/**
- * Extracts the Ruff config section from a pyproject-like TOML config.
- */
-function configRuffSection(
-  config: Record<string, toml.TomlPrimitive>
-): Record<string, toml.TomlPrimitive> | undefined {
-  if (!((config as any)?.['tool']?.['ruff'] instanceof Object)) {
-    return undefined;
-  }
-
-  return (config as any)['tool']['ruff'];
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ async function workspaceFromEnvironment(
       if (filename === 'pyproject.toml') {
         const ruffSection = configRuffSection(config);
         if (ruffSection !== undefined) {
-          return new Workspace({ ...config, ...overrides });
+          return new Workspace({ ...ruffSection, ...overrides });
         }
       } else {
         return new Workspace({ ...config, ...overrides });
@@ -163,11 +163,12 @@ async function workspaceFromEnvironment(
  */
 function configRuffSection(
   config: Record<string, toml.TomlPrimitive>
-): toml.TomlPrimitive | undefined {
-  if (!(config['tool'] instanceof Object)) {
-    return false;
+): Record<string, toml.TomlPrimitive> | undefined {
+  if (!((config as any)?.['tool']?.['ruff'] instanceof Object)) {
+    return undefined;
   }
-  return (config['tool'] as Record<string, toml.TomlPrimitive>)['ruff'];
+
+  return (config as any)['tool']['ruff'];
 }
 
 /**

--- a/ui-tests/jupyter_server_test_config.py
+++ b/ui-tests/jupyter_server_test_config.py
@@ -4,9 +4,13 @@
 opens the server to the world and provide access to JupyterLab
 JavaScript objects through the global window variable.
 """
+
 from jupyterlab.galata import configure_jupyter_server
 
 configure_jupyter_server(c)
+
+# Allow access to '.ruff.toml' in tests
+c.ContentsManager.allow_hidden = True
 
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"

--- a/ui-tests/tests/jupyter_ruff.spec.ts
+++ b/ui-tests/tests/jupyter_ruff.spec.ts
@@ -46,23 +46,32 @@ test('should format the cell', async ({ notebook }) => {
   );
 });
 
-test('should format the cell with config', async ({ notebook, tmpPath }) => {
-  notebook.contents.uploadContent(
-    `indent-width = 2`,
-    'text',
-    path.join(tmpPath, 'ruff.toml')
-  );
+[
+  ['ruff.toml', `indent-width = 2`],
+  ['.ruff.toml', `indent-width = 2`],
+  ['pyproject.toml', `[tool.ruff]\nindent-width = 2`]
+].forEach(([filename, contents]) => {
+  test(`should format the cell (${filename})`, async ({
+    notebook,
+    tmpPath
+  }) => {
+    notebook.contents.uploadContent(
+      contents,
+      'text',
+      path.join(tmpPath, filename)
+    );
 
-  await notebook.open('WithConfig.ipynb');
-  await notebook.selectCells(0);
+    await notebook.open('WithConfig.ipynb');
+    await notebook.selectCells(0);
 
-  await notebook.page.evaluate(async () => {
-    await window.jupyterapp.commands.execute('jupyter-ruff:format-cell');
+    await notebook.page.evaluate(async () => {
+      await window.jupyterapp.commands.execute('jupyter-ruff:format-cell');
+    });
+
+    expect(await notebook.getCellTextInput(0)).toBe(
+      await notebook.getCellTextInput(1)
+    );
   });
-
-  expect(await notebook.getCellTextInput(0)).toBe(
-    await notebook.getCellTextInput(1)
-  );
 });
 
 test('should isort the cell', async ({ notebook }) => {
@@ -78,21 +87,27 @@ test('should isort the cell', async ({ notebook }) => {
   );
 });
 
-test('should isort the cell with config', async ({ notebook, tmpPath }) => {
-  notebook.contents.uploadContent(
-    `[lint.isort]\nfrom-first = true`,
-    'text',
-    path.join(tmpPath, 'ruff.toml')
-  );
+[
+  ['ruff.toml', `[lint.isort]\nfrom-first = true`],
+  ['.ruff.toml', `[lint.isort]\nfrom-first = true`],
+  ['pyproject.toml', `[tool.ruff.lint.isort]\nfrom-first = true`]
+].forEach(([filename, contents]) => {
+  test(`should isort the cell (${filename})`, async ({ notebook, tmpPath }) => {
+    notebook.contents.uploadContent(
+      contents,
+      'text',
+      path.join(tmpPath, filename)
+    );
 
-  await notebook.open('IsortWithConfig.ipynb');
-  await notebook.selectCells(0);
+    await notebook.open('IsortWithConfig.ipynb');
+    await notebook.selectCells(0);
 
-  await notebook.page.evaluate(async () => {
-    await window.jupyterapp.commands.execute('jupyter-ruff:format-cell');
+    await notebook.page.evaluate(async () => {
+      await window.jupyterapp.commands.execute('jupyter-ruff:format-cell');
+    });
+
+    expect(await notebook.getCellTextInput(0)).toBe(
+      await notebook.getCellTextInput(1)
+    );
   });
-
-  expect(await notebook.getCellTextInput(0)).toBe(
-    await notebook.getCellTextInput(1)
-  );
 });


### PR DESCRIPTION
+ Fixes `pyproject.toml` config handling.
+ Adds more tests for all supported config files.
+ Removes ruff-wasm warning for top-level `select` config key, this also required making config merging more robust.