### PR TITLE
Disable link check workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,12 +161,3 @@ jobs:
         path: |
           ui-tests/test-results
           ui-tests/playwright-report
-
-  check_links:
-    name: Check Links
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1


### PR DESCRIPTION
Some of the links (mostly NPM) randomly return 403, probably because of DDOS protection.